### PR TITLE
Update ncurses 6.2 -> 6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A script or building a static tmux for linux which should run on a wide selectio
 **Versions**
 * [tmux 3.2a](https://github.com/tmux/tmux/)
 * [musl 1.2.2](https://www.musl-libc.org/)
-* [ncurses 6.2](https://invisible-island.net/ncurses/)
+* [ncurses 6.3](https://invisible-island.net/ncurses/)
 * [libevent 2.1.12](https://github.com/libevent/libevent/)
 
 Binaries available in releases.

--- a/build-static-tmux.sh
+++ b/build-static-tmux.sh
@@ -44,7 +44,7 @@ TMUX_BIN="tmux.${OS}-${ARCH}"
 ######################################
 TMUX_VERSION=3.2a
 MUSL_VERSION=1.2.2
-NCURSES_VERSION=6.2
+NCURSES_VERSION=6.3
 LIBEVENT_VERSION=2.1.12
 UPX_VERSION=3.96
 ######################################


### PR DESCRIPTION
The URL of ncurses now points version 6.3 instead of 6.2 and results build failure. This PR updates the ncurses version.
